### PR TITLE
build(bugfix):fix asm file do not ar in out-of-tree ffmpeg build

### DIFF
--- a/ffmpeg/Makefile
+++ b/ffmpeg/Makefile
@@ -111,9 +111,9 @@ else
 endif
 
 NASUFFIX = $(subst $(DELIM),.,$(CURDIR))
-EXTOBJS  = $(NASRCS:=$(NASUFFIX)$(OBJEXT))
+EXTOBJS  = $(NASRCS:%=$(PREFIX)%$(NASUFFIX)$(OBJEXT))
 
-$(EXTOBJS): %.asm$(NASUFFIX)$(OBJEXT): %.asm
+$(EXTOBJS): $(PREFIX)%.asm$(NASUFFIX)$(OBJEXT): %.asm
 	$(Q) nasm $(NAFLAGS) $< -o $@
 	$(Q) strip -x $@
 endif


### PR DESCRIPTION
## Summary

fix asm file do not ar in out-of-tree ffmpeg build

## Impact

bugfix

## Testing

```
./build.sh vendor/sim/boards/vela/configs/vela --cmake 

```


