### PR TITLE
Refactor RIL build scripts (Makefile & CMakeLists)

### DIFF
--- a/ril/CMakeLists.txt
+++ b/ril/CMakeLists.txt
@@ -27,6 +27,18 @@ if(CONFIG_RILD)
                ${CMAKE_CURRENT_LIST_DIR}/ril/librilutils)
 
   if(CONFIG_GOLDFISH_RIL)
+    set(TEMP_FILE "${CMAKE_BINARY_DIR}/advancedFeatures.ini")
+
+    add_custom_command(
+      OUTPUT ${TEMP_FILE}
+      COMMAND
+        ${CMAKE_COMMAND} -E echo "ModemSimulator = on" > ${TEMP_FILE}
+      COMMENT "advancedFeatures.ini"
+      VERBATIM
+    )
+
+    add_custom_target(generate_temp_file ALL DEPENDS ${TEMP_FILE})
+
     file(GLOB APPEND_FILES ${CMAKE_CURRENT_LIST_DIR}/ril/reference-ril/*.c)
     list(APPEND RILD_SRCS ${APPEND_FILES})
 

--- a/ril/Makefile
+++ b/ril/Makefile
@@ -11,6 +11,7 @@ CXXFLAGS += ${INCDIR_PREFIX}ril/libril
 CXXFLAGS += ${INCDIR_PREFIX}ril/librilutils
 
 CXXSRCS += ril/libril/ril.cpp
+CXXSRCS += ril/libril/parcel.cpp
 CXXSRCS += ril/libril/ril_event.cpp
 
 CSRCS += $(wildcard ril/librilutils/*.c)


### PR DESCRIPTION
1. Remove the dependency on the system binder in the Makefile.
2. In CMakeLists.txt, add the following behavior: generate an advancedFeatures.ini file at build time. The simulator relies on this file and reads its contents to determine whether the ModemSimulator feature should be enabled.