### PR TITLE
always define HAVE_PF_INET6 for compile error without open net_ipv6 macro, because nuttx/include/sys/socket.h have been #define AF_INET6 PF_INET6

### DIFF
--- a/c-ares/Kconfig
+++ b/c-ares/Kconfig
@@ -35,7 +35,7 @@ config LIB_CARES_TIMEOUT
 config LIB_CARES_MAXTIMEOUT
 	int "Maximum DNS receive timeout"
 	default 2000
-	--help--
+	---help---
 		Maximum DNS receive timeout, unit: milliseconds.
 
 config LIB_CARES_TRIES

--- a/c-ares/ares_config.h
+++ b/c-ares/ares_config.h
@@ -220,10 +220,8 @@
 /* Define to 1 if you have the <ntstatus.h> header file. */
 /* #undef HAVE_NTSTATUS_H */
 
-#ifdef CONFIG_NET_IPv6
 /* Define to 1 if you have PF_INET6 */
 #define HAVE_PF_INET6 1
-#endif
 
 /* Define to 1 if you have `pipe` */
 #define HAVE_PIPE 1


### PR DESCRIPTION
### Summary
nuttx/include/sys/socket.h have been #define AF_INET6 PF_INET6, so always define HAVE_PF_INET6 for compile error without open net_ipv6 macro.

### Impact
N/A

### Testing
N/A