### PR TITLE
ofono: New config to control wasm build

### DIFF
--- a/dbus/Makefile
+++ b/dbus/Makefile
@@ -161,6 +161,6 @@ BIN := $(APPDIR)/staging/libtelephony.a
 endif
 
 WASM_INITIAL_MEMORY = 131072
-WASM_BUILD = n
+WASM_BUILD = both
 
 include $(APPDIR)/Application.mk

--- a/glib/Makefile
+++ b/glib/Makefile
@@ -42,6 +42,6 @@ ifneq ($(NOEXPORTSRCS),)
 BIN := $(APPDIR)/staging/libtelephony.a
 endif
 
-WASM_BUILD = y
+WASM_BUILD = both
 
 include $(APPDIR)/Application.mk

--- a/ofono/Kconfig
+++ b/ofono/Kconfig
@@ -65,6 +65,13 @@ config OFONO_PLUGIN_DIR
 	---help---
 		Directory for the loading plugins.
 
+config OFONO_WASM
+	bool "Compile to Wasm"
+	default n
+	---help---
+		Compile ofono to Wasm module instead of builitn app,
+		only available if any wasm runtime eanbled.
+
 config OFONO_DATA_LOG_OVER_MIWEAR
 	bool "support data log over miwear"
 	default n

--- a/ofono/Makefile
+++ b/ofono/Makefile
@@ -133,7 +133,9 @@ clean::
 
 endif
 
+ifneq ($(CONFIG_OFONO_WASM),)
 WASM_INITIAL_MEMORY = 327680
 WASM_BUILD          = n
+endif
 
 include $(APPDIR)/Application.mk

--- a/ofono/Makefile
+++ b/ofono/Makefile
@@ -135,7 +135,7 @@ endif
 
 ifneq ($(CONFIG_OFONO_WASM),)
 WASM_INITIAL_MEMORY = 327680
-WASM_BUILD          = n
+WASM_BUILD          = y
 endif
 
 include $(APPDIR)/Application.mk


### PR DESCRIPTION

## Summary

*Added new Kconfig option OFONO_WASM to control Wasm compilation*

## Impact

*This change introduces a new configuration option that allows compiling ofono as a WebAssembly module instead of a built-in application. The option is disabled by default and only available when a Wasm runtime is enabled.*

## Testing

*Verified the new Kconfig option appears in menuconfig when Wasm runtime is enabled.
Tested building with OFONO_WASM enabled/disabled.*

