### PR TITLE
ffmpeg: fix compile failed in x86-64

### DIFF
--- a/ffmpeg/Makefile
+++ b/ffmpeg/Makefile
@@ -98,7 +98,7 @@ endef
 $(foreach D,$(FFLIBS-yes),$(eval $(call DOSUBDIR,lib$(D))))
 
 ifneq ($(NASRCS),)
-NAFLAGS = -g -F dwarf -P$(DST_PATH)/config.asm
+NAFLAGS = -g -F dwarf -DPIC -Wl,-mcmodel=large -P$(DST_PATH)/config.asm
 NAFLAGS += ${INCDIR_PREFIX}$(SRC_PATH)/
 ifneq ($(wildcard $(SRC_PATH)/libavcodec/$(ARCH)),)
   NAFLAGS += ${INCDIR_PREFIX}$(SRC_PATH)/libavcodec/$(ARCH)


### PR DESCRIPTION
## Summary

ffmpeg: fix compile failed in x86-64

```
/home/ligd/platform/dev-system/apps/staging/libffmpeg.a(vp8dsp_loopfilter.asm.home.ligd.platform.dev-system.external.ffmpeg_3.o): in function ff_vp8_v_loop_filter_simple_sse2:
ffmpeg/libavcodec/x86/vp8dsp_loopfilter.asm:(.text+0x5b): relocation truncated to fit: R_X86_64_32S against symbol ff_pb_80 defined in .rodata.ff_pb_80 section in /home/ligd/platform/dev-system/apps/staging/libffmpeg.a(constants.c.home.ligd.platform.dev-system.external.ffmpeg_3.o)
ffmpeg/libavcodec/x86/vp8dsp_loopfilter.asm:(.text+0x70): relocation truncated to fit: R_X86_64_32S against .rodata
ffmpeg/libavcodec/x86/vp8dsp_loopfilter.asm:(.text+0xae): relocation truncated to fit: R_X86_64_32S against .rodata
ffmpeg/libavcodec/x86/vp8dsp_loopfilter.asm:(.text+0xbb): relocation truncated to fit: R_X86_64_32S against .rodata
ffmpeg/libavcodec/x86/vp8dsp_loopfilter.asm:(.text+0xc4): relocation truncated to fit: R_X86_64_32S against symbol ff_pb_3 defined in .rodata.ff_pb_3 section in /home/ligd/platform/dev-system/apps/staging/libffmpeg.a(constants.c.home.ligd.platform.dev-system.external.ffmpeg_3.o)
/home/ligd/platform/dev-system/apps/staging/libffmpeg.a(vp8dsp_loopfilter.asm.home.ligd.platform.dev-system.external.ffmpeg_3.o): in function ff_vp8_h_loop_filter_simple_sse2:
ffmpeg/libavcodec/x86/vp8dsp_loopfilter.asm:(.text+0x238): relocation truncated to fit: R_X86_64_32S against symbol ff_pb_80 defined in .rodata.ff_pb_80 section in /home/ligd/platform/dev-system/apps/staging/libffmpeg.a(constants.c.home.ligd.platform.dev-system.external.ffmpeg_3.o)
ffmpeg/libavcodec/x86/vp8dsp_loopfilter.asm:(.text+0x24d): relocation truncated to fit: R_X86_64_32S against .rodata
ffmpeg/libavcodec/x86/vp8dsp_loopfilter.asm:(.text+0x28b): relocation truncated to fit: R_X86_64_32S against .rodata
ffmpeg/libavcodec/x86/vp8dsp_loopfilter.asm:(.text+0x298): relocation truncated to fit: R_X86_64_32S against .rodata
ffmpeg/libavcodec/x86/vp8dsp_loopfilter.asm:(.text+0x2a1): relocation truncated to fit: R_X86_64_32S against symbol ff_pb_3 defined in .rodata.ff_pb_3 section in /home/ligd/platform/dev-system/apps/staging/libffmpeg.a(constants.c.home.ligd.platform.dev-system.external.ffmpeg_3.o)
/home/ligd/platform/dev-system/apps/staging/libffmpeg.a(vp8dsp_loopfilter.asm.home.ligd.platform.dev-system.external.ffmpeg_3.o): in function ff_vp8_v_loop_filter_simple_ssse3
```

## Impact

ffmpeg

## Testing

CI & CT

