### PR TITLE
helix-aac: add MACRO for PNS feature to disable MPEG4 support

### DIFF
--- a/libhelix-aac/Kconfig
+++ b/libhelix-aac/Kconfig
@@ -24,6 +24,12 @@ config LIB_HELIX_AAC
 
 if LIB_HELIX_AAC
 
+config LIB_HELIX_AAC_PNS
+	bool "AAC-Perceptual Noise Substitution"
+	default y
+	---help---
+		Enable support for the MPEG4-AAC
+
 config LIB_HELIX_AAC_SBR
 	bool "AAC-Spectral Band Replication"
 	default n


### PR DESCRIPTION
## Summary

helix-aac: add MACRO for PNS feature to disable MPEG4 support


## Impact

helix-aac compile


## Testing

aac dec


Note:

related with https://github.com/open-vela/external_libhelix-aac/pull/1