### PR TITLE
ethercat: adapts stable-1.6 branch compilation

### DIFF
--- a/ethercat/Kconfig
+++ b/ethercat/Kconfig
@@ -28,16 +28,6 @@ config ETHERCAT_MASTER
 
 if ETHERCAT_MASTER
 
-config ETHERCAT_MASTER_EXAMMPLE
-	tristate "EtherCAT master example"
-	default n
-
-config ETHERCAT_MASTER_PROGNAME
-	string "EtherCAT master program name"
-	default "ethercat_master"
-	---help---
-	  This is the name of the etherCAT master.
-
 config ETHERCAT_MASTER_PRIORITY
 	int "EtherCAT master task priority"
 	default 100
@@ -45,6 +35,29 @@ config ETHERCAT_MASTER_PRIORITY
 config ETHERCAT_MASTER_STACKSIZE
 	int "EtherCAT master stack size"
 	default DEFAULT_TASK_STACKSIZE
+
+config ETHERCAT_MASTER_IFNAME
+	string "The name of the network card used for EtherCAT transmission"
+	default "eth0"
+
+config ETHERCAT_MASTER_RING_SIZE
+	int "The external datagram ring is used for slave FSMs"
+	default 10
+	---help---
+	  This is the size of the external datagram ring.
+
+config ETHERCAT_MASTER_DEVICE_COUNT
+	int "The count of etherCAT master"
+	range 1 32
+	default 1
+	---help---
+	  This is the count of etherCAT master.
+
+config ETHERCAT_MASTER_DEVICE_LIST
+	string "EtherCAT master device MAC address list"
+	default "\"02:02:03:04:05:06\", \"\""
+	---help---
+	  This is the devices MAC address list of etherCAT master.
 
 endif
 

--- a/ethercat/Makefile
+++ b/ethercat/Makefile
@@ -15,63 +15,61 @@
 #
 
 include $(APPDIR)/Make.defs
+
 ifeq ($(CONFIG_ETHERCAT_MASTER),y)
 
-CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/external/ethercat/ethercat/devices
-
-CSRCS += \
-    ethercat/master/soe_request.c \
-    ethercat/master/slave_config.c \
-    ethercat/master/slave.c \
-    ethercat/master/sdo_request.c \
-    ethercat/master/sdo_entry.c \
-    ethercat/master/sdo.c \
-    ethercat/master/reg_request.c \
-    ethercat/master/pdo_list.c \
-    ethercat/master/pdo_entry.c \
-    ethercat/master/pdo.c \
-    ethercat/master/os.c \
-    ethercat/master/master_socket.c \
-    ethercat/master/module.c \
-    ethercat/master/mbox_gateway_request.c \
-    ethercat/master/master.c \
-    ethercat/master/mailbox.c \
-    ethercat/master/fsm_soe.c \
-    ethercat/master/fsm_slave_scan.c \
-    ethercat/master/fsm_slave_config.c \
-    ethercat/master/fsm_reboot.c \
-    ethercat/master/fsm_mbox_gateway.c \
-    ethercat/master/fsm_master.c \
-    ethercat/master/fsm_foe.c \
-    ethercat/master/fsm_coe.c \
-    ethercat/master/domain.c \
-    ethercat/master/device.c \
-    ethercat/master/datagram_pair.c \
-    ethercat/master/datagram.c \
-    ethercat/master/coe_emerg_ring.c \
-    ethercat/master/sync_config.c \
-    ethercat/master/sync.c \
-    ethercat/master/soe_errors.c \
-    ethercat/master/fsm_slave.c \
-    ethercat/master/fsm_sii.c \
-    ethercat/master/fsm_pdo_entry.c \
-    ethercat/master/fsm_pdo.c \
-    ethercat/master/fsm_change.c \
-    ethercat/master/fmmu_config.c \
-    ethercat/master/doxygen.c \
-    ethercat/master/dict_request.c \
-    ethercat/master/ioctl.c \
-
+CFLAGS += -Wno-discarded-qualifiers
+CFLAGS += -Wno-pointer-sign
+CFLAGS += -Wno-stringop-truncation
+CFLAGS += -Wno-implicit-function-declaration
 CFLAGS += ${DEFINE_PREFIX}VERSION='"${VERSION}"'
 
-ifeq ($(CONFIG_ETHERCAT_MASTER_EXAMMPLE),y)
-MAINSRC   += ethercat/examples/velaos/main.c
-PROGNAME  += $(CONFIG_ETHERCAT_MASTER_PROGNAME)
-PRIORITY  += $(CONFIG_ETHERCAT_MASTER_PRIORITY)
-STACKSIZE += $(CONFIG_ETHERCAT_MASTER_STACKSIZE)
-MODULE    += $(CONFIG_ETHERCAT_MASTER)
-endif
+CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/external/ethercat
+CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/external/ethercat/nuttx
 
+CSRCS += \
+    ethercat/master/coe_emerg_ring.c \
+    ethercat/master/datagram.c \
+    ethercat/master/datagram_pair.c \
+    ethercat/master/device.c \
+    ethercat/master/domain.c \
+    ethercat/master/doxygen.c \
+    ethercat/master/flag.c \
+    ethercat/master/fmmu_config.c \
+    ethercat/master/foe_request.c \
+    ethercat/master/fsm_change.c \
+    ethercat/master/fsm_coe.c \
+    ethercat/master/fsm_foe.c \
+    ethercat/master/fsm_master.c \
+    ethercat/master/fsm_pdo.c \
+    ethercat/master/fsm_pdo_entry.c \
+    ethercat/master/fsm_sii.c \
+    ethercat/master/fsm_slave.c \
+    ethercat/master/fsm_slave_config.c \
+    ethercat/master/fsm_slave_scan.c \
+    ethercat/master/fsm_soe.c \
+    ethercat/master/ioctl.c \
+    ethercat/master/mailbox.c \
+    ethercat/master/master.c \
+    ethercat/master/module.c \
+    ethercat/master/pdo.c \
+    ethercat/master/pdo_entry.c \
+    ethercat/master/pdo_list.c \
+    ethercat/master/reg_request.c \
+    ethercat/master/sdo.c \
+    ethercat/master/sdo_entry.c \
+    ethercat/master/sdo_request.c \
+    ethercat/master/slave.c \
+    ethercat/master/slave_config.c \
+    ethercat/master/soe_errors.c \
+    ethercat/master/soe_request.c \
+    ethercat/master/sync.c \
+    ethercat/master/sync_config.c \
+    ethercat/master/voe_handler.c \
+    nuttx/linux/kthread.c \
+    nuttx/linux/skbuff.c \
+    nuttx/ec_cdev.c \
+    nuttx/ethercat.c
 endif
 
 ifeq ($(CONFIG_ETHERCAT_TOOL),y)

--- a/ethercat/config.h
+++ b/ethercat/config.h
@@ -1,0 +1,99 @@
+/* config.h.  Generated from config.h.in by configure.  */
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Debug interfaces enabled */
+/* #undef EC_DEBUG_IF */
+
+/* Debug ring enabled */
+/* #undef EC_DEBUG_RING */
+
+/* EoE support enabled */
+//#define EC_EOE 1
+
+/* Use CPU timestamp counter */
+/* #undef EC_HAVE_CYCLES */
+
+/* Use vendor id / product code wildcards */
+/* #undef EC_IDENT_WILDCARDS */
+
+/* Use loop control registers */
+/* #undef EC_LOOP_CONTROL */
+
+/* Max. number of Ethernet devices per master */
+#define EC_MAX_NUM_DEVICES 1
+
+/* Force refclk to OP */
+/* #undef EC_REFCLKOP */
+
+/* Read alias adresses from register */
+/* #undef EC_REGALIAS */
+
+/* RTDM interface enabled */
+/* #undef EC_RTDM */
+
+/* Output to syslog in RT context */
+#define EC_RT_SYSLOG 1
+
+/* Assign SII to PDI */
+#define EC_SII_ASSIGN 1
+
+/* Use hrtimer for scheduling */
+/* #undef EC_USE_HRTIMER */
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#define LT_OBJDIR ".libs/"
+
+/* Name of package */
+#define PACKAGE "ethercat"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "fp@igh.de"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "ethercat"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "ethercat 1.6.1"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "ethercat"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "1.6.1"
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+

--- a/ethercat/nuttx/asm/div64.h
+++ b/ethercat/nuttx/asm/div64.h
@@ -1,0 +1,45 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __ASM_DIV64_H
+#define __ASM_DIV64_H
+
+#define do_div(n, base) ({                          \
+        unsigned int __base = (base);               \
+        unsigned int __rem;                         \
+        __rem = ((unsigned long long)(n)) % __base; \
+        (n) = ((unsigned long long)(n)) / __base;   \
+        __rem;                                      \
+})
+
+#endif /* __ASM_DIV64_H */

--- a/ethercat/nuttx/ec_cdev.c
+++ b/ethercat/nuttx/ec_cdev.c
@@ -1,0 +1,166 @@
+/****************************************************************************
+ * external/ethercat/nuttx/ec_cdev.c
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *  notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *  notice, this list of conditions and the following disclaimer in
+ *  the documentation and/or other materials provided with the
+ *  distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *  used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <fcntl.h>
+
+#include <nuttx/kmalloc.h>
+#include <nuttx/fs/fs.h>
+
+#include "../ethercat/master/cdev.h"
+#include "../ethercat/master/master.h"
+#include "../ethercat/master/ethernet.h"
+#include "../ethercat/master/ioctl.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+typedef struct
+{
+  FAR ec_cdev_t *cdev;    /* Character device. */
+  ec_ioctl_context_t ctx; /* Context. */
+} ec_cdev_priv_t;
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int ec_cdev_open(FAR struct file *filep);
+static int ec_cdev_close(FAR struct file *filep);
+static int ec_cdev_ioctl(FAR struct file *filep, int, unsigned long);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/** File operation callbacks for the EtherCAT character device.
+ */
+
+static const struct file_operations g_ec_cdev_ops =
+{
+  ec_cdev_open,  /* open */
+  ec_cdev_close, /* close */
+  NULL,          /* read */
+  NULL,          /* write */
+  NULL,          /* seek */
+  ec_cdev_ioctl, /* ioctl */
+  NULL,          /* mmap */
+  NULL,          /* truncate */
+  NULL           /* poll */
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int ec_cdev_open(FAR struct file *filep)
+{
+  FAR struct inode *inode = filep->f_inode;
+  FAR ec_cdev_t *cdev = inode->i_private;
+  FAR ec_cdev_priv_t *priv;
+
+  priv = kmm_zalloc(sizeof(ec_cdev_priv_t));
+  if (priv == NULL)
+    {
+      EC_MASTER_ERR(cdev->master,
+              "Failed to allocate memory for private data structure.\n");
+      return -ENOMEM;
+    }
+
+  priv->cdev = cdev;
+  priv->ctx.writable = (filep->f_oflags & O_WRONLY) != 0;
+
+  filep->f_priv = priv;
+
+  EC_MASTER_DBG(cdev->master, 0, "File opened.\n");
+  return 0;
+}
+
+static int ec_cdev_close(FAR struct file *filep)
+{
+  FAR ec_cdev_priv_t *priv = (FAR ec_cdev_priv_t *)filep->f_priv;
+  FAR ec_master_t *master = priv->cdev->master;
+
+  if (priv->ctx.requested)
+    {
+      ecrt_release_master(master);
+    }
+
+  EC_MASTER_DBG(master, 0, "File closed.\n");
+
+  kmm_free(priv);
+  return 0;
+}
+
+static int ec_cdev_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
+{
+  FAR ec_cdev_priv_t *priv = (FAR ec_cdev_priv_t *)filep->f_priv;
+
+  EC_MASTER_DBG(priv->cdev->master, 0,
+                "ioctl(filep = 0x%p, cmd = 0x%08x (0x%02x), arg = 0x%lx)\n",
+                filep, cmd, _IOC_NR(cmd), arg);
+
+  return ec_ioctl(priv->cdev->master, &priv->ctx, cmd, (FAR void *)arg);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int ec_cdev_init(FAR ec_cdev_t *cdev, FAR ec_master_t *master, dev_t dev_num)
+{
+  int ret;
+
+  cdev->master = master;
+
+  ret = register_driver("/dev/EtherCAT", &g_ec_cdev_ops, 0644, cdev);
+
+  if (ret)
+    {
+      EC_MASTER_ERR(master, "Failed to add character device!\n");
+    }
+
+  ether_device_init();
+
+  return ret;
+}
+
+void ec_cdev_clear(FAR ec_cdev_t *cdev)
+{
+  unregister_driver("/dev/EtherCAT");
+}

--- a/ethercat/nuttx/ethercat.c
+++ b/ethercat/nuttx/ethercat.c
@@ -1,0 +1,218 @@
+/****************************************************************************
+ * external/ethercat/nuttx/ethercat.c
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <errno.h>
+#include <sys/queue.h>
+
+#include <unistd.h>
+
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <netpacket/packet.h>
+
+#include <linux/netdevice.h>
+#include <linux/skbuff.h>
+
+#include "../ethercat/devices/ecdev.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define ETH_P_ECAT 0x88A4    /* Ether type: EtherCat Protocol */
+
+struct ether_device
+{
+  struct net_device dev;
+  FAR struct ec_device *ec;
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int ether_device_open(FAR struct net_device *dev);
+static int ether_device_stop(FAR struct net_device *dev);
+static int ether_device_start_xmit(FAR struct sk_buff *skb,
+                                   FAR struct net_device *dev);
+static void ether_device_poll(FAR struct net_device *dev);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const unsigned char g_ether_device_mac[] =
+{
+  0x02, 0x02, 0x03, 0x04, 0x05, 0x06
+};
+
+struct net_device_ops g_ether_device_ops =
+{
+  .ndo_open       = ether_device_open,
+  .ndo_stop       = ether_device_stop,
+  .poll           = ether_device_poll,
+  .ndo_start_xmit = ether_device_start_xmit
+};
+
+struct ether_device g_ether_device =
+{
+  {
+    .name       = "dummy",
+    .dev_addr   = g_ether_device_mac,
+    .netdev_ops = &g_ether_device_ops,
+  }
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int ether_device_open(FAR struct net_device *dev)
+{
+  FAR struct ether_device *ethdev = (FAR struct ether_device *)dev;
+  struct sockaddr_ll sll;
+  struct timeval timeout;
+  struct ifreq ifr;
+  int ifindex;
+  int i;
+  int ret;
+
+  ret = psock_socket(AF_PACKET, SOCK_RAW | SOCK_NONBLOCK,
+                     HTONS(ETH_P_ECAT), &ethdev->dev.sock);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  memset(&sll, 0, sizeof(struct sockaddr_ll));
+
+  timeout.tv_sec  = 0;
+  timeout.tv_usec = 1;
+
+  psock_setsockopt(&ethdev->dev.sock, SOL_SOCKET, SO_RCVTIMEO, &timeout,
+                    sizeof(timeout));
+  psock_setsockopt(&ethdev->dev.sock, SOL_SOCKET, SO_SNDTIMEO, &timeout,
+                    sizeof(timeout));
+
+  i = 1;
+  psock_setsockopt(&ethdev->dev.sock, SOL_SOCKET, SO_DONTROUTE, &i,
+                    sizeof(i));
+
+  /* connect socket to NIC by name */
+
+  strlcpy(ethdev->dev.name, CONFIG_ETHERCAT_MASTER_IFNAME,
+          sizeof(ethdev->dev.name));
+  strlcpy(ifr.ifr_name, CONFIG_ETHERCAT_MASTER_IFNAME, sizeof(ifr.ifr_name));
+  psock_ioctl(&ethdev->dev.sock, SIOCGIFINDEX, &ifr);
+  ifindex = ifr.ifr_ifindex;
+  ifr.ifr_flags = 0;
+
+  /* reset flags of NIC interface */
+
+  psock_ioctl(&ethdev->dev.sock, SIOCGIFFLAGS, &ifr);
+
+  /* set flags of NIC interface, here promiscuous and broadcast */
+
+  ifr.ifr_flags = ifr.ifr_flags | IFF_BROADCAST;
+  psock_ioctl(&ethdev->dev.sock, SIOCGIFFLAGS, &ifr);
+
+  sll.sll_family   = AF_PACKET;
+  sll.sll_protocol = HTONS(ETH_P_ECAT);
+  sll.sll_ifindex  = ifindex;
+
+  ret = psock_bind(&ethdev->dev.sock, (FAR struct sockaddr *)&sll,
+                   sizeof(struct sockaddr_ll));
+  if (ret < -1)
+    {
+      psock_close(&ethdev->dev.sock);
+      return ret;
+    }
+
+  ecdev_set_link(ethdev->ec, 1);
+  return 0;
+}
+
+static int ether_device_stop(FAR struct net_device *dev)
+{
+  return 0;
+}
+
+static int ether_device_start_xmit(FAR struct sk_buff *skb,
+                                   FAR struct net_device *dev)
+{
+  FAR struct ether_device *ethdev = (FAR struct ether_device *)dev;
+
+  /* use raw socket send as ether_device_start_xmit */
+
+  return psock_send(&ethdev->dev.sock, skb->data, skb->len, 0);
+}
+
+static void ether_device_poll(FAR struct net_device *dev)
+{
+  FAR struct ether_device *ethdev = (FAR struct ether_device *)dev;
+  char frame[CONFIG_NET_ETH_PKTSIZE];
+  ssize_t len;
+
+  /* use raw socket receive as poll */
+
+  len = psock_recv(&ethdev->dev.sock, frame, CONFIG_NET_ETH_PKTSIZE, 0);
+  if (len > 0)
+    {
+      ecdev_receive(ethdev->ec, frame, len);
+    }
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void ether_device_init(void)
+{
+  g_ether_device.ec = ecdev_offer(
+                    (FAR struct net_device *)&g_ether_device,
+                    g_ether_device.dev.netdev_ops->poll, NULL);
+  ecdev_open(g_ether_device.ec);
+}

--- a/ethercat/nuttx/linux/cdev.h
+++ b/ethercat/nuttx/linux/cdev.h
@@ -1,0 +1,46 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/cdev.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_CDEV_H
+#define __LINUX_CDEV_H
+
+/****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+
+struct cdev
+{
+};
+
+#endif /* __LINUX_CDEV_H */

--- a/ethercat/nuttx/linux/compiler.h
+++ b/ethercat/nuttx/linux/compiler.h
@@ -1,0 +1,51 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/compiler.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_COMPILER_H
+#define __LINUX_COMPILER_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/compiler.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define unlikely predict_false
+#define likely   predict_true
+
+#endif /* __LINUX_COMPILER_H */

--- a/ethercat/nuttx/linux/delay.h
+++ b/ethercat/nuttx/linux/delay.h
@@ -1,0 +1,50 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/delay.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_DELAY_H
+#define __LINUX_DELAY_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <linux/sched.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define delay(t) usleep(TICK2USEC(t))
+
+#endif /* __LINUX_DELAY_H */

--- a/ethercat/nuttx/linux/device.h
+++ b/ethercat/nuttx/linux/device.h
@@ -1,0 +1,56 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/device.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_DEVICE_H
+#define __LINUX_DEVICE_H
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define class_create(...)  NULL
+#define class_destroy(x)
+
+#define device_create(...) NULL
+#define device_unregister(x)
+
+/****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+
+struct class
+{
+};
+
+#endif /* __LINUX_DEVICE_H */

--- a/ethercat/nuttx/linux/err.h
+++ b/ethercat/nuttx/linux/err.h
@@ -1,0 +1,74 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/err.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_ERR_H
+#define __LINUX_ERR_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <errno.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#undef errno
+
+#define MAX_ERRNO 4095
+
+#define IS_ERR_VALUE(x) \
+        ((unsigned long)(FAR void *)(x) >= (unsigned long)-MAX_ERRNO)
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+static inline FAR void *ERR_PTR(long error)
+{
+    return (FAR void *)error;
+}
+
+static inline int IS_ERR(FAR const void *ptr)
+{
+    return IS_ERR_VALUE(ptr);
+}
+
+static inline long PTR_ERR(FAR const void *ptr)
+{
+    return (long)ptr;
+}
+
+#endif /* __LINUX_ERR_H */

--- a/ethercat/nuttx/linux/etherdevice.h
+++ b/ethercat/nuttx/linux/etherdevice.h
@@ -1,0 +1,64 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/etherdevice.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_ETHERDEVICE_H
+#define __LINUX_ETHERDEVICE_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <netinet/if_ether.h>
+
+#include <linux/types.h>
+
+#define NETDEV_TX_OK 0
+
+/****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+
+struct net_device;
+struct sk_buff;
+
+struct net_device_ops
+{
+  CODE int (*ndo_open)(FAR struct net_device *dev);
+  CODE int (*ndo_stop)(FAR struct net_device *dev);
+  CODE int (*ndo_start_xmit)(FAR struct sk_buff *skb,
+                             FAR struct net_device *dev);
+  CODE void (*poll)(FAR struct net_device *dev);
+};
+
+#endif /* __LINUX_ETHERDEVICE_H */

--- a/ethercat/nuttx/linux/fs.h
+++ b/ethercat/nuttx/linux/fs.h
@@ -1,0 +1,45 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/fs.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_FS_H
+#define __LINUX_FS_H
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define alloc_chrdev_region(a, b, c, d) 0
+#define unregister_chrdev_region(a, b)
+
+#endif /* __LINUX_FS_H */

--- a/ethercat/nuttx/linux/hrtimer.h
+++ b/ethercat/nuttx/linux/hrtimer.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/hrtimer.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_HRTIMER_H
+#define __LINUX_HRTIMER_H
+
+#endif /* __LINUX_HRTIMER_H */

--- a/ethercat/nuttx/linux/if_ether.h
+++ b/ethercat/nuttx/linux/if_ether.h
@@ -1,0 +1,44 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/if_ether.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_IF_ETHER_H
+#define __LINUX_IF_ETHER_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <netinet/if_ether.h>
+
+#endif /* __LINUX_IF_ETHER_H */

--- a/ethercat/nuttx/linux/interrupt.h
+++ b/ethercat/nuttx/linux/interrupt.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/interrupt.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_INTERRUPT_H
+#define __LINUX_INTERRUPT_H
+
+#endif /* __LINUX_INTERRUPT_H */

--- a/ethercat/nuttx/linux/ioctl.h
+++ b/ethercat/nuttx/linux/ioctl.h
@@ -1,0 +1,55 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/ioctl.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_IOCTL_H
+#define __LINUX_IOCTL_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/fs/ioctl.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define __KERNEL__
+
+#define _IO(ect, nr)         _IOC((ect) << 8, nr)
+#define _IOR(ect, nr, type)  _IOC((ect) << 8, nr)
+#define _IOW(ect, nr, type)  _IOC((ect) << 8, nr)
+#define _IOWR(ect, nr, type) _IOC((ect) << 8, nr)
+
+#endif /* __LINUX_IOCTL_H */

--- a/ethercat/nuttx/linux/irq_work.h
+++ b/ethercat/nuttx/linux/irq_work.h
@@ -1,0 +1,58 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/irq_work.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_IRQ_WORK_H
+#define __LINUX_IRQ_WORK_H
+
+/****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+
+struct irq_work
+{
+};
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+static inline void init_irq_work(FAR void *x, FAR void *y)
+{
+}
+
+static inline void irq_work_sync(FAR void *x)
+{
+}
+
+#endif /* __LINUX_IRQ_WORK_H */

--- a/ethercat/nuttx/linux/jiffies.h
+++ b/ethercat/nuttx/linux/jiffies.h
@@ -1,0 +1,52 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/jiffies.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_JIFFIES_H
+#define __LINUX_JIFFIES_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <time.h>
+
+#include <linux/timer.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define jiffies clock()
+
+#endif  /* __LINUX_JIFFIES_H */

--- a/ethercat/nuttx/linux/kernel.h
+++ b/ethercat/nuttx/linux/kernel.h
@@ -1,0 +1,69 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/kernel.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_KERNEL_H
+#define __LINUX_KERNEL_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdio.h>
+#include <string.h>
+#include <syslog.h>
+
+#include <sys/param.h>
+
+#include <linux/err.h>
+#include <linux/semaphore.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define min MIN
+#define max MAX
+
+#define KERN_INFO
+#define KERN_ERR
+#define KERN_WARNING
+#define KERN_DEBUG
+#define KERN_CONT
+#define GFP_KERNEL 0
+
+#define simple_strtoul strtoul
+
+#define printk(fmt, ...) syslog(LOG_INFO, fmt, ##__VA_ARGS__)
+
+#endif /* __LINUX_KERNEL_H */

--- a/ethercat/nuttx/linux/kobject.h
+++ b/ethercat/nuttx/linux/kobject.h
@@ -1,0 +1,46 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/kobject.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_KOBJECT_H
+#define __LINUX_KOBJECT_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <linux/compiler.h>
+#include <linux/device.h>
+#include <linux/slab.h>
+
+#endif /* __LINUX_KOBJECT_H */

--- a/ethercat/nuttx/linux/kstrtox.h
+++ b/ethercat/nuttx/linux/kstrtox.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/kstrtox.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_KSTRTOX_H
+#define __LINUX_KSTRTOX_H
+
+#endif /* __LINUX_KSTRTOX_H */

--- a/ethercat/nuttx/linux/kthread.c
+++ b/ethercat/nuttx/linux/kthread.c
@@ -1,0 +1,126 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/kthread.c
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *  notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *  notice, this list of conditions and the following disclaimer in
+ *  the documentation and/or other materials provided with the
+ *  distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *  used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdio.h>
+#include <sys/types.h>
+
+#include <nuttx/kthread.h>
+
+#include <linux/kthread.h>
+#include <linux/slab.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#undef kthread_create
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int kthread_work(int argc, FAR char *argv[])
+{
+  FAR struct task_struct *t =
+      (FAR struct task_struct *)((uintptr_t)strtoul(argv[1], NULL, 16));
+  int ret;
+
+  ret = t->threadfn(t->data);
+  nxnxsem_post(&t->semexit);
+
+  return ret;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+FAR struct task_struct *kthread_run(CODE int (*threadfn)(FAR void *data),
+                                    FAR void *data,
+                                    FAR const char *name)
+{
+  FAR struct task_struct *t;
+  FAR char *argv[2];
+  char      arg1[32];
+  int       ret;
+
+  t = kmalloc(sizeof(struct task_struct), GFP_KERNEL);
+  if (t == NULL)
+    {
+      return (FAR struct task_struct *)-ENOMEM;
+    }
+
+  t->running  = true;
+  t->threadfn = threadfn;
+  t->data     = data;
+  nxsem_init(&t->semexit, 0, 0);
+
+  snprintf(arg1, sizeof(arg1), "%p", t);
+  argv[0] = arg1;
+  argv[1] = NULL;
+
+  ret = kthread_create(name, CONFIG_ETHERCAT_MASTER_PRIORITY,
+                       CONFIG_ETHERCAT_MASTER_STACKSIZE, kthread_work, argv);
+  if (ret < 0)
+    {
+      kfree(t);
+      return (FAR struct task_struct *)(uintptr_t)ret;
+    }
+
+  t->threadid = ret;
+  return t;
+}
+
+void kthread_stop(FAR struct task_struct *t)
+{
+  t->running = false;
+  nxnxsem_wait(&t->semexit);
+  free(t);
+}
+
+void kthread_bind(FAR struct task_struct *t, unsigned int cpu)
+{
+  cpu_set_t cpuset;
+
+  if (t->running)
+    {
+      CPU_ZERO(&cpuset);
+      CPU_SET(cpu, &cpuset);
+      sched_setaffinity(t->threadid, sizeof(cpu_set_t), &cpuset);
+    }
+}

--- a/ethercat/nuttx/linux/kthread.h
+++ b/ethercat/nuttx/linux/kthread.h
@@ -1,0 +1,75 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/kthread.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_KTHREAD_H
+#define __LINUX_KTHREAD_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/semaphore.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define kthread_create        kthread_run
+#define kthread_should_stop() (!master->thread->running)
+#define wake_up_process(t)    0
+
+/****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+
+struct task_struct
+{
+  pid_t threadid;
+  bool running;
+  CODE int (*threadfn)(FAR void *data);
+  FAR void *data;
+  sem_t semexit;
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+FAR struct task_struct *kthread_run(CODE int (*threadfn)(FAR void *data),
+                                    FAR void *data,
+                                    FAR const char *name);
+void kthread_stop(FAR struct task_struct *t);
+void kthread_bind(FAR struct task_struct *t, unsigned int cpu);
+
+#endif /* __LINUX_KTHREAD_H */

--- a/ethercat/nuttx/linux/list.h
+++ b/ethercat/nuttx/linux/list.h
@@ -1,0 +1,355 @@
+/*
+ * Copyright © 2010 Intel Corporation
+ * Copyright © 2010 Francisco Jerez <currojerez@riseup.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ */
+
+/* Modified by Ben Skeggs <bskeggs@redhat.com> to match kernel list APIs */
+
+#ifndef _XORG_LIST_H_
+#define _XORG_LIST_H_
+
+/**
+ * @file Classic doubly-link circular list implementation.
+ * For real usage examples of the linked list, see the file test/list.c
+ *
+ * Example:
+ * We need to keep a list of struct foo in the parent struct bar, i.e. what
+ * we want is something like this.
+ *
+ *     struct bar {
+ *          ...
+ *          struct foo *list_of_foos; -----> struct foo {}, struct foo {}, struct foo{}
+ *          ...
+ *     }
+ *
+ * We need one list head in bar and a list element in all list_of_foos (both are of
+ * data type 'struct list_head').
+ *
+ *     struct bar {
+ *          ...
+ *          struct list_head list_of_foos;
+ *          ...
+ *     }
+ *
+ *     struct foo {
+ *          ...
+ *          struct list_head entry;
+ *          ...
+ *     }
+ *
+ * Now we initialize the list head:
+ *
+ *     struct bar bar;
+ *     ...
+ *     INIT_LIST_HEAD(&bar.list_of_foos);
+ *
+ * Then we create the first element and add it to this list:
+ *
+ *     struct foo *foo = malloc(...);
+ *     ....
+ *     list_add(&foo->entry, &bar.list_of_foos);
+ *
+ * Repeat the above for each element you want to add to the list. Deleting
+ * works with the element itself.
+ *      list_del(&foo->entry);
+ *      free(foo);
+ *
+ * Note: calling list_del(&bar.list_of_foos) will set bar.list_of_foos to an empty
+ * list again.
+ *
+ * Looping through the list requires a 'struct foo' as iterator and the
+ * name of the field the subnodes use.
+ *
+ * struct foo *iterator;
+ * list_for_each_entry(iterator, &bar.list_of_foos, entry) {
+ *      if (iterator->something == ...)
+ *             ...
+ * }
+ *
+ * Note: You must not call list_del() on the iterator if you continue the
+ * loop. You need to run the safe for-each loop instead:
+ *
+ * struct foo *iterator, *next;
+ * list_for_each_entry_safe(iterator, next, &bar.list_of_foos, entry) {
+ *      if (...)
+ *              list_del(&iterator->entry);
+ * }
+ *
+ */
+
+/**
+ * The linkage struct for list nodes. This struct must be part of your
+ * to-be-linked struct. struct list_head is required for both the head of the
+ * list and for each list node.
+ *
+ * Position and name of the struct list_head field is irrelevant.
+ * There are no requirements that elements of a list are of the same type.
+ * There are no requirements for a list head, any struct list_head can be a list
+ * head.
+ */
+#undef bool
+#define bool int
+struct list_head {
+    struct list_head *next, *prev;
+};
+
+/**
+ * Initialize the list as an empty list.
+ *
+ * Example:
+ * INIT_LIST_HEAD(&bar->list_of_foos);
+ *
+ * @param The list to initialized.
+ */
+#define LIST_HEAD_INIT(name) { &(name), &(name) }
+
+#define LIST_HEAD(name) \
+    struct list_head name = LIST_HEAD_INIT(name)
+
+static inline void
+INIT_LIST_HEAD(struct list_head *list)
+{
+    list->next = list->prev = list;
+}
+
+static inline void
+__list_add(struct list_head *entry,
+       struct list_head *prev, struct list_head *next)
+{
+    next->prev = entry;
+    entry->next = next;
+    entry->prev = prev;
+    prev->next = entry;
+}
+
+/**
+ * Insert a new element after the given list head. The new element does not
+ * need to be initialised as empty list.
+ * The list changes from:
+ *      head → some element → ...
+ * to
+ *      head → new element → older element → ...
+ *
+ * Example:
+ * struct foo *newfoo = malloc(...);
+ * list_add(&newfoo->entry, &bar->list_of_foos);
+ *
+ * @param entry The new element to prepend to the list.
+ * @param head The existing list.
+ */
+static inline void
+list_add(struct list_head *entry, struct list_head *head)
+{
+    __list_add(entry, head, head->next);
+}
+
+/**
+ * Append a new element to the end of the list given with this list head.
+ *
+ * The list changes from:
+ *      head → some element → ... → lastelement
+ * to
+ *      head → some element → ... → lastelement → new element
+ *
+ * Example:
+ * struct foo *newfoo = malloc(...);
+ * list_add_tail(&newfoo->entry, &bar->list_of_foos);
+ *
+ * @param entry The new element to prepend to the list.
+ * @param head The existing list.
+ */
+static inline void
+list_add_tail(struct list_head *entry, struct list_head *head)
+{
+    __list_add(entry, head->prev, head);
+}
+
+static inline void
+__list_del(struct list_head *prev, struct list_head *next)
+{
+    next->prev = prev;
+    prev->next = next;
+}
+
+/**
+ * Remove the element from the list it is in. Using this function will reset
+ * the pointers to/from this element so it is removed from the list. It does
+ * NOT free the element itself or manipulate it otherwise.
+ *
+ * Using list_del on a pure list head (like in the example at the top of
+ * this file) will NOT remove the first element from
+ * the list but rather reset the list as empty list.
+ *
+ * Example:
+ * list_del(&foo->entry);
+ *
+ * @param entry The element to remove.
+ */
+static inline void
+list_del(struct list_head *entry)
+{
+    __list_del(entry->prev, entry->next);
+}
+
+static inline void
+list_del_init(struct list_head *entry)
+{
+    __list_del(entry->prev, entry->next);
+    INIT_LIST_HEAD(entry);
+}
+
+static inline void list_move_tail(struct list_head *list,
+                  struct list_head *head)
+{
+    __list_del(list->prev, list->next);
+    list_add_tail(list, head);
+}
+
+/**
+ * Check if the list is empty.
+ *
+ * Example:
+ * list_empty(&bar->list_of_foos);
+ *
+ * @return True if the list contains one or more elements or False otherwise.
+ */
+static inline bool
+list_empty(struct list_head *head)
+{
+    return head->next == head;
+}
+
+/**
+ * Returns a pointer to the container of this list element.
+ *
+ * Example:
+ * struct foo* f;
+ * f = container_of(&foo->entry, struct foo, entry);
+ * assert(f == foo);
+ *
+ * @param ptr Pointer to the struct list_head.
+ * @param type Data type of the list element.
+ * @param member Member name of the struct list_head field in the list element.
+ * @return A pointer to the data struct containing the list head.
+ */
+#ifndef container_of
+#define container_of(ptr, type, member) \
+    (type *)((char *)(ptr) - (char *) &((type *)0)->member)
+#endif
+
+/**
+ * Alias of container_of
+ */
+#define list_entry(ptr, type, member) \
+    container_of(ptr, type, member)
+
+/**
+ * Retrieve the first list entry for the given list pointer.
+ *
+ * Example:
+ * struct foo *first;
+ * first = list_first_entry(&bar->list_of_foos, struct foo, list_of_foos);
+ *
+ * @param ptr The list head
+ * @param type Data type of the list element to retrieve
+ * @param member Member name of the struct list_head field in the list element.
+ * @return A pointer to the first list element.
+ */
+#define list_first_entry(ptr, type, member) \
+    list_entry((ptr)->next, type, member)
+
+/**
+ * Retrieve the last list entry for the given listpointer.
+ *
+ * Example:
+ * struct foo *first;
+ * first = list_last_entry(&bar->list_of_foos, struct foo, list_of_foos);
+ *
+ * @param ptr The list head
+ * @param type Data type of the list element to retrieve
+ * @param member Member name of the struct list_head field in the list element.
+ * @return A pointer to the last list element.
+ */
+#define list_last_entry(ptr, type, member) \
+    list_entry((ptr)->prev, type, member)
+
+#define __container_of(ptr, sample, member)                \
+    (void *)container_of((ptr), typeof(*(sample)), member)
+
+/**
+ * Loop through the list given by head and set pos to struct in the list.
+ *
+ * Example:
+ * struct foo *iterator;
+ * list_for_each_entry(iterator, &bar->list_of_foos, entry) {
+ *      [modify iterator]
+ * }
+ *
+ * This macro is not safe for node deletion. Use list_for_each_entry_safe
+ * instead.
+ *
+ * @param pos Iterator variable of the type of the list elements.
+ * @param head List head
+ * @param member Member name of the struct list_head in the list elements.
+ *
+ */
+#define list_for_each_entry(pos, head, member)                \
+    for (pos = __container_of((head)->next, pos, member);        \
+     &pos->member != (head);                    \
+     pos = __container_of(pos->member.next, pos, member))
+
+/**
+ * Loop through the list, keeping a backup pointer to the element. This
+ * macro allows for the deletion of a list element while looping through the
+ * list.
+ *
+ * See list_for_each_entry for more details.
+ */
+#define list_for_each_entry_safe(pos, tmp, head, member)        \
+    for (pos = __container_of((head)->next, pos, member),        \
+     tmp = __container_of(pos->member.next, pos, member);        \
+     &pos->member != (head);                    \
+     pos = tmp, tmp = __container_of(pos->member.next, tmp, member))
+
+
+#define list_for_each_entry_reverse(pos, head, member)            \
+    for (pos = __container_of((head)->prev, pos, member);        \
+         &pos->member != (head);                    \
+         pos = __container_of(pos->member.prev, pos, member))
+
+#define list_for_each_entry_continue(pos, head, member)            \
+    for (pos = __container_of(pos->member.next, pos, member);    \
+         &pos->member != (head);                    \
+         pos = __container_of(pos->member.next, pos, member))
+
+#define list_for_each_entry_continue_reverse(pos, head, member)        \
+    for (pos = __container_of(pos->member.prev, pos, member);    \
+         &pos->member != (head);                    \
+         pos = __container_of(pos->member.prev, pos, member))
+
+#define list_for_each_entry_from(pos, head, member)            \
+    for (;                                \
+         &pos->member != (head);                    \
+         pos = __container_of(pos->member.next, pos, member))
+
+#endif

--- a/ethercat/nuttx/linux/module.h
+++ b/ethercat/nuttx/linux/module.h
@@ -1,0 +1,89 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/module.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_MODULE_H
+#define __LINUX_MODULE_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/compiler.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define module_init(x)
+#define module_exit(x)
+
+#define EXPORT_SYMBOL(x)
+#define MODULE_AUTHOR(x)
+#define MODULE_DESCRIPTION(x)
+#define MODULE_LICENSE(x)
+#define MODULE_VERSION(x)
+#define module_param_array(...)
+#define MODULE_PARM_DESC(...)
+#define module_param_named(...)
+
+#define __init
+#define __exit
+#define __user
+
+/****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+
+struct module_os
+{
+};
+
+struct module
+{
+};
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+static inline int try_module_get(FAR void *x)
+{
+    return 1;
+}
+
+static inline void module_put(FAR void *x)
+{
+}
+
+#endif /* __LINUX_MODULE_H */

--- a/ethercat/nuttx/linux/netdevice.h
+++ b/ethercat/nuttx/linux/netdevice.h
@@ -1,0 +1,63 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/netdevice.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_NETDEVICE_H
+#define __LINUX_NETDEVICE_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <net/if.h>
+#include <nuttx/net/net.h>
+#include <linux/etherdevice.h>
+#include <linux/module.h>
+
+/****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+
+struct net_device_stats
+{
+};
+
+struct net_device
+{
+    char                       name[IFNAMSIZ];
+    struct socket              sock;
+    FAR unsigned char         *dev_addr;
+    FAR struct net_device_ops *netdev_ops;
+};
+
+#endif /* __LINUX_NETDEVICE_H */

--- a/ethercat/nuttx/linux/rtmutex.h
+++ b/ethercat/nuttx/linux/rtmutex.h
@@ -1,0 +1,74 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/rtmutex.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_RTMUTEX_H
+#define __LINUX_RTMUTEX_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/mutex.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define rt_mutex mutex_s
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+static void inline rt_mutex_init(FAR struct mutex_s *mutex)
+{
+  nxmutex_init(mutex);
+}
+
+static void inline rt_mutex_lock(FAR struct mutex_s *mutex)
+{
+  nxmutex_lock(mutex);
+}
+
+static void inline rt_mutex_unlock(FAR struct mutex_s *mutex)
+{
+  nxmutex_unlock(mutex);
+}
+
+static int inline rt_mutex_lock_interruptible(FAR struct mutex_s *mutex)
+{
+  return nxmutex_lock(mutex);
+}
+
+#endif /* __LINUX_RTMUTEX_H */

--- a/ethercat/nuttx/linux/sched.h
+++ b/ethercat/nuttx/linux/sched.h
@@ -1,0 +1,57 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/sched.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_SCHED_H
+#define __LINUX_SCHED_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <unistd.h>
+
+#include <nuttx/clock.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define TASK_INTERRUPTIBLE 0x00000001
+
+#define set_current_state(state)
+
+#define schedule_timeout(t) usleep(TICK2USEC(t))
+#define schedule() usleep(1)
+
+#endif /* __LINUX_SCHED_H */

--- a/ethercat/nuttx/linux/semaphore.h
+++ b/ethercat/nuttx/linux/semaphore.h
@@ -1,0 +1,56 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/semaphore.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_SEMAPHORE_H
+#define __LINUX_SEMAPHORE_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/semaphore.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define semaphore sem_s
+
+#define sema_init(s, v)       nxsem_init(s, 0, v)
+#define down(s)               nxsem_wait(s)
+#define down_interruptible(s) nxsem_wait(s)
+#define up(s)                 nxsem_post(s)
+#define down_trylock(s)       nxsem_trywait(s)
+
+#endif /* __LINUX_SEMAPHORE_H */

--- a/ethercat/nuttx/linux/skbuff.c
+++ b/ethercat/nuttx/linux/skbuff.c
@@ -1,0 +1,89 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/skbuff.c
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *  notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *  notice, this list of conditions and the following disclaimer in
+ *  the documentation and/or other materials provided with the
+ *  distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *  used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <linux/skbuff.h>
+#include <linux/slab.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+FAR struct sk_buff *dev_alloc_skb(unsigned int length)
+{
+  FAR uint8_t *data;
+  FAR struct sk_buff *skb;
+
+  data = kmalloc(length, GFP_KERNEL);
+  if (data == NULL)
+    {
+      return NULL;
+    }
+
+  skb = kmalloc(sizeof(struct sk_buff), GFP_KERNEL);
+  if (skb == NULL)
+    {
+      return NULL;
+    }
+
+  skb->head = data;
+  skb->data = data;
+
+  skb->tail = skb->data;
+
+  return skb;
+}
+
+void skb_reserve(FAR struct sk_buff *skb, int len)
+{
+  skb->data += len;
+  skb->tail += len;
+}
+
+FAR unsigned char *skb_push(FAR struct sk_buff *skb, unsigned int len)
+{
+  skb->data -= len;
+  skb->len  += len;
+
+  return skb->data;
+}
+
+void dev_kfree_skb(FAR struct sk_buff *skb)
+{
+  kfree(skb->head);
+  kfree(skb);
+}

--- a/ethercat/nuttx/linux/skbuff.h
+++ b/ethercat/nuttx/linux/skbuff.h
@@ -1,0 +1,67 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/skbuff.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_SKBUFF_H
+#define __LINUX_SKBUFF_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdint.h>
+
+/****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+
+struct net_device;
+struct sk_buff
+{
+  FAR struct net_device *dev;
+  uint32_t len;
+  FAR uint8_t *data;
+  FAR uint8_t *head;
+  FAR uint8_t *tail;
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+FAR struct sk_buff *dev_alloc_skb(unsigned int length);
+void skb_reserve(FAR struct sk_buff *skb, int len);
+FAR unsigned char *skb_push(FAR struct sk_buff *skb, unsigned int len);
+void dev_kfree_skb(FAR struct sk_buff *skb);
+
+#endif /* __LINUX_SKBUFF_H */

--- a/ethercat/nuttx/linux/slab.h
+++ b/ethercat/nuttx/linux/slab.h
@@ -1,0 +1,54 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/slab.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_SLAB_H
+#define __LINUX_SLAB_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/kmalloc.h>
+
+#include <linux/kernel.h>
+#include <linux/types.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define kmalloc(s, f) kmm_zalloc(s)
+#define kfree(p)      kmm_free(p)
+
+#endif /* __LINUX_SLAB_H */

--- a/ethercat/nuttx/linux/string.h
+++ b/ethercat/nuttx/linux/string.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/string.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_STRING_H
+#define __LINUX_STRING_H
+
+#endif /* __LINUX_STRING_H */

--- a/ethercat/nuttx/linux/time.h
+++ b/ethercat/nuttx/linux/time.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/time.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_TIME_H
+#define __LINUX_TIME_H
+
+#endif /* __LINUX_TIME_H */

--- a/ethercat/nuttx/linux/timer.h
+++ b/ethercat/nuttx/linux/timer.h
@@ -1,0 +1,50 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/timer.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_TIMER_H
+#define __LINUX_TIMER_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <time.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define HZ CLK_TCK
+
+#endif /* __LINUX_TIMER_H */

--- a/ethercat/nuttx/linux/timex.h
+++ b/ethercat/nuttx/linux/timex.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/timex.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_TIMEX_H
+#define __LINUX_TIMEX_H
+
+#endif /* __LINUX_TIMEX_H */

--- a/ethercat/nuttx/linux/types.h
+++ b/ethercat/nuttx/linux/types.h
@@ -1,0 +1,57 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/types.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_TYPES_H
+#define __LINUX_TYPES_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdint.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+typedef uint8_t            u8;
+typedef uint16_t           u16;
+typedef uint32_t           u32;
+typedef unsigned long long u64;
+typedef int8_t             s8;
+typedef int16_t            s16;
+typedef int32_t            s32;
+typedef long long          s64;
+
+#endif /* __LINUX_TYPES_H */

--- a/ethercat/nuttx/linux/uaccess.h
+++ b/ethercat/nuttx/linux/uaccess.h
@@ -1,0 +1,47 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/uaccess.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_UACCESS_H
+#define __LINUX_UACCESS_H
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define copy_to_user(p, d, n) memcpy(p, d, n)
+#define __copy_to_user copy_to_user
+#define copy_from_user(d, p, n) memcpy(d, p, n)
+#define __copy_from_user copy_from_user
+
+#endif /* __LINUX_UACCESS_H */

--- a/ethercat/nuttx/linux/version.h
+++ b/ethercat/nuttx/linux/version.h
@@ -1,0 +1,45 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/version.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_VERSION_H
+#define __LINUX_VERSION_H
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define LINUX_VERSION_CODE  0
+#define KERNEL_VERSION(...) 0
+
+#endif /* __LINUX_VERSION_H */

--- a/ethercat/nuttx/linux/vmalloc.h
+++ b/ethercat/nuttx/linux/vmalloc.h
@@ -1,0 +1,54 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/vmalloc.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_VMALLOC_H
+#define __LINUX_VMALLOC_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/kmalloc.h>
+
+#include <linux/types.h>
+#include <linux/uaccess.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define vmalloc(s) kmm_zalloc(s)
+#define vfree(p)   kmm_free(p)
+
+#endif /* __LINUX_VMALLOC_H */

--- a/ethercat/nuttx/linux/wait.h
+++ b/ethercat/nuttx/linux/wait.h
@@ -1,0 +1,102 @@
+/****************************************************************************
+ * external/ethercat/nuttx/linux/wait.h
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_WAIT_H
+#define __LINUX_WAIT_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/semaphore.h>
+#include <nuttx/mutex.h>
+#include <linux/jiffies.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define __wait_event(q,c,i)                         \
+({                                                  \
+  int __ret = 0;                                    \
+  while (!(c))                                      \
+    {                                               \
+      if (i)                                        \
+        {                                           \
+          __ret = nxsem_wait(&(q));                 \
+        }                                           \
+      else                                          \
+        {                                           \
+          __ret = nxsem_wait_uninterruptible(&(q)); \
+        }                                           \
+    }                                               \
+  __ret;                                            \
+})
+
+#define wait_event(q, c)               __wait_event(q, c, 0)
+#define wait_event_interruptible(q, c) __wait_event(q, c, 1)
+
+/****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+
+typedef sem_t wait_queue_head_t;
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+inline int init_waitqueue_head(FAR wait_queue_head_t *q)
+{
+  nxsem_init(q, 0, 0);
+
+  return OK;
+}
+
+inline int wake_up_interruptible(FAR wait_queue_head_t *q)
+{
+  return nxsem_post(q);
+}
+
+inline void wake_up_all(FAR wait_queue_head_t *q)
+{
+  int semval;
+
+  while (nxsem_get_value(q, &semval) >= 0 && semval <= 0)
+    {
+      nxsem_post(q);
+    }
+}
+
+#endif /* __LINUX_WAIT_H */

--- a/ethercat/nuttx/linux/workqueue.h
+++ b/ethercat/nuttx/linux/workqueue.h
@@ -1,0 +1,63 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2024 Xiaomi InC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __LINUX_WORKQUEUE_H
+#define __LINUX_WORKQUEUE_H
+
+/****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+
+struct work_struct
+{
+};
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+static inline int schedule_work(FAR void *x)
+{
+    return 0;
+}
+
+static inline int cancel_work_sync(FAR void *x)
+{
+    return 0;
+}
+
+static inline void INIT_WORK(FAR void *x, FAR void *y)
+{
+}
+
+#endif /* __LINUX_WORKQUEUE_H */


### PR DESCRIPTION

## Summary
Add a compilation adaptation for version 1.6 of ethercat, which compiles ethercat as a kernel module, basically maintaining the same features as linux.

## Impact
ethercat support

## Testing
cortex-m33 board

