### PR TITLE
zblue: optimization: merged bt driver thread into btservice thread[1/3]

### DIFF
--- a/zblue/Makefile
+++ b/zblue/Makefile
@@ -724,10 +724,6 @@ CSRCS += zblue/port/lib/os/assert.c
 CSRCS += zblue/port/sections/defines.c
 CSRCS += zblue/port/subsys/fs/fs.c
 
-ifeq ($(CONFIG_BT_H4),y)
-  CSRCS += zblue/port/drivers/bluetooth/hci/h4.c
-endif
-
 CFLAGS += -Wno-format-zero-length -Wno-implicit-function-declaration
 CFLAGS += -Wno-unused-but-set-variable -Wno-unused-function -Wno-unused-variable
 CFLAGS += -Wno-format -Wno-pointer-sign -Wno-strict-prototypes -Wno-implicit-int -Wno-shadow


### PR DESCRIPTION
bug:v/51584

disable bt driver handle, and move to btservice loop handle.

 depends-on: [ open-vela/frameworks_bluetooth/pull/200 open-vela/external_zblue/pull/54] 

## Summary

merged bt driver thread into btservice thread

## Impact

BR/LE  HCI TX and RX 

## Testing

LE scan and BR bond test pass

