### PR TITLE
zblue: move bt driver handle to exist btservice thread

### DIFF
--- a/zblue/CMakeLists.txt
+++ b/zblue/CMakeLists.txt
@@ -782,10 +782,6 @@ if(CONFIG_BT)
     zblue/port/subsys/fs/fs.c
   )
 
-  if(CONFIG_BT_H4)
-    list(APPEND CSRCS zblue/port/drivers/bluetooth/hci/h4.c)
-  endif()
-
   if(CONFIG_BT_SAMPLE)
     set(ZBLUE_STACKSIZE ${CONFIG_BT_SAMPLE_STACKSIZE})
   else()

--- a/zblue/Makefile
+++ b/zblue/Makefile
@@ -724,10 +724,6 @@ CSRCS += zblue/port/lib/os/assert.c
 CSRCS += zblue/port/sections/defines.c
 CSRCS += zblue/port/subsys/fs/fs.c
 
-ifeq ($(CONFIG_BT_H4),y)
-  CSRCS += zblue/port/drivers/bluetooth/hci/h4.c
-endif
-
 CFLAGS += -Wno-format-zero-length -Wno-implicit-function-declaration
 CFLAGS += -Wno-unused-but-set-variable -Wno-unused-function -Wno-unused-variable
 CFLAGS += -Wno-format -Wno-pointer-sign -Wno-strict-prototypes -Wno-implicit-int -Wno-shadow


### PR DESCRIPTION
depends-on: [open-vela/frameworks_bluetooth/pull/254 open-vela/external_zblue/pull/67]

## Summary

## Impact

bt hci tx/rx process.

## Testing

qemu test pass 

