### PR TITLE
zblue: cmake: add hid profile build

### DIFF
--- a/zblue/CMakeLists.txt
+++ b/zblue/CMakeLists.txt
@@ -163,6 +163,9 @@ if(CONFIG_BT)
       if(CONFIG_BT_RFCOMM)
         list(APPEND CSRCS ${CLASSICDIR}/rfcomm.c)
       endif()
+      if(CONFIG_BT_HID_DEVICE)
+        list(APPEND CSRCS ${CLASSICDIR}/hid_device.c)
+      endif()
 
       list(APPEND CSRCS
         ${CLASSICDIR}/br.c

--- a/zblue/Makefile
+++ b/zblue/Makefile
@@ -120,6 +120,9 @@ ifeq ($(CONFIG_BT_HCI),y)
     ifeq ($(CONFIG_BT_RFCOMM),y)
       CSRCS += $(CLASSICDIR)/rfcomm.c
     endif
+    ifeq ($(CONFIG_BT_HID_DEVICE),y)
+      CSRCS += $(CLASSICDIR)/hid_device.c
+    endif
 
     ifeq ($(CONFIG_BT_CLASSIC),y)
       CSRCS += $(CLASSICDIR)/br.c \


### PR DESCRIPTION
bug: v/74770

depends-on: [open-vela/frameworks_bluetooth/pull/274 open-vela/external_zblue/pull/108 open-vela/vendor_openvela/pull/29]

## Summary

add hid stack source codes build

## Impact

HID feature

## Testing

Local test HID conect/send etc pass

