### PR TITLE
Add zbluelog interface compilation support

### DIFF
--- a/zblue/CMakeLists.txt
+++ b/zblue/CMakeLists.txt
@@ -785,6 +785,7 @@ if(CONFIG_BT)
     zblue/port/lib/os/assert.c
     zblue/port/sections/defines.c
     zblue/port/subsys/fs/fs.c
+    zblue/port/subsys/logging/log.c
   )
 
   if(CONFIG_BT_SAMPLE)

--- a/zblue/Makefile
+++ b/zblue/Makefile
@@ -731,6 +731,7 @@ CSRCS += zblue/port/lib/net_buf/buf.c
 CSRCS += zblue/port/lib/os/assert.c
 CSRCS += zblue/port/sections/defines.c
 CSRCS += zblue/port/subsys/fs/fs.c
+CSRCS += zblue/port/subsys/logging/log.c
 
 CFLAGS += -Wno-format-zero-length -Wno-implicit-function-declaration
 CFLAGS += -Wno-unused-but-set-variable -Wno-unused-function -Wno-unused-variable


### PR DESCRIPTION
bug: v/81365

Add zblue/port/subsys/logging/log.c source file to build configuration.
