### PR TITLE
zblue: propagate headers to libbluetooth via nuttx_link_libraries.

### DIFF
--- a/zblue/CMakeLists.default.txt
+++ b/zblue/CMakeLists.default.txt
@@ -876,9 +876,10 @@ if(CONFIG_BT)
     ${ZBLUE_DIR}/subsys/bluetooth
     ${ZBLUE_DIR}/subsys/bluetooth/host
     ${ZBLUE_DIR}/subsys/settings/include
+    ${ZBLUE_DIR}/subsys/settings/include/settings
   )
 
-  target_link_libraries(zblue PRIVATE zblue_headers)
+  target_link_libraries(zblue PUBLIC zblue_headers)
   target_include_directories(zblue BEFORE PRIVATE
     ${ZBLUE_DIR}/port/include
     ${ZBLUE_DIR}/port/kernel/include


### PR DESCRIPTION
bug: v/85506

Add Zephyr sys/settings include paths and link zblue to zblue_headers with PUBLIC so dependents like libbluetooth get include dirs via nuttx_link_libraries. Reorder include dirs for host/keys.h and settings_zblue.h.