### PR TITLE
zblue: add bt_probe include path for debug probe headers

### DIFF
--- a/zblue/CMakeLists.default.txt
+++ b/zblue/CMakeLists.default.txt
@@ -877,6 +877,7 @@ if(CONFIG_BT)
     ${ZBLUE_DIR}/subsys/bluetooth/host
     ${ZBLUE_DIR}/subsys/settings/include
     ${ZBLUE_DIR}/subsys/settings/include/settings
+    ${NUTTX_APPS_DIR}/frameworks/connectivity/bluetooth/debug/probe
   )
 
   target_link_libraries(zblue PUBLIC zblue_headers)

--- a/zblue/Makefile.default
+++ b/zblue/Makefile.default
@@ -740,6 +740,7 @@ CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" zblue/subsys/bluetooth/mesh}
 CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" zblue/subsys/bluetooth/services}
 CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" zblue/subsys/settings/include}
 CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/crypto/tinycrypt/tinycrypt/lib/include}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/frameworks/connectivity/bluetooth/debug/probe}
 
 ifeq ($(CONFIG_BT_SHELL),y)
   PROGNAME += zblue


### PR DESCRIPTION
Add frameworks/connectivity/bluetooth/debug/probe to zblue include paths in both CMake and Makefile build systems, enabling zblue host stack files to include bt_probe_hci.h and bt_probe_rfcomm.h for event trace probe instrumentation.

depends-on: [ open-vela/frameworks_bluetooth/pull/575 ]