### PR TITLE
bluetooth: hogp: add build system registration

### DIFF
--- a/zblue/CMakeLists.default.txt
+++ b/zblue/CMakeLists.default.txt
@@ -282,9 +282,15 @@ if(CONFIG_BT)
         list(APPEND CSRCS ${SVRSDIR}/nus/bt_nus_auto_start_bt.c)
       endif()
     endif()
-  endif()
 
-  set(MESHDIR ${BTDIR}/mesh)
+    if(CONFIG_BT_HOGP_DEVICE)
+      list(APPEND CSRCS ${SVRSDIR}/hogp/hogp_device.c)
+    endif()
+
+    if(CONFIG_BT_HOGP_HOST)
+      list(APPEND CSRCS ${SVRSDIR}/hogp/hogp_host.c)
+    endif()
+  endif()
 
   if(CONFIG_BT_MESH)
     list(APPEND CSRCS

--- a/zblue/Makefile.default
+++ b/zblue/Makefile.default
@@ -197,6 +197,14 @@ ifeq ($(CONFIG_BT_CONN),y)
     endif
   endif
 
+  ifeq ($(CONFIG_BT_HOGP_DEVICE),y)
+    CSRCS += $(SVRSDIR)/hogp/hogp_device.c
+  endif
+
+  ifeq ($(CONFIG_BT_HOGP_HOST),y)
+    CSRCS += $(SVRSDIR)/hogp/hogp_host.c
+  endif
+
   ifeq ($(CONFIG_BT_OTS),y)
     CSRCS += $(SVRSDIR)/ots/ots.c \
              $(SVRSDIR)/ots/ots_l2cap.c \


### PR DESCRIPTION
## Summary

Add HOGP Device/Host compilation entries in both `CMakeLists.default.txt`
and `Makefile.default` so that `CONFIG_BT_HOGP_DEVICE` and `CONFIG_BT_HOGP_HOST`
actually compile `hogp_device.c` / `hogp_host.c` into the final binary.

## Why

`external/zblue/zblue/subsys/bluetooth/services/hogp/{hogp_device,hogp_host}.c`
are introduced by the inner zblue feature branch (see external_zblue#226), but
the outer zblue wrapper build system (`Makefile.default` + `CMakeLists.default.txt`)
did not register these source files, so turning on `CONFIG_BT_HOGP_DEVICE=y`
and `CONFIG_BT_HOGP_HOST=y` had no effect — HOGP object files never participated
in the link.

This PR adds the CSRCS entries in both build systems. After merge,
`CONFIG_BT_HOGP_DEVICE=y` / `CONFIG_BT_HOGP_HOST=y` correctly include the
HOGP implementation into `libapps.a`.

## Dependencies

- Depends on inner zblue PR open-vela/external_zblue#226
- Related framework PR: open-vela/frameworks_bluetooth#583

## How tested

Local build on `vendor/openvela/boards/vela/configs/goldfish-armeabi-v7a-ap`
with `CONFIG_BT_HOGP_DEVICE=y` + `CONFIG_BT_HOGP_HOST=y`:
- Build succeeds (exit 0)
- `nm nuttx | grep bt_hogp_` shows all `bt_hogp_device_*` / `bt_hogp_host_*` T symbols
- HOGP `.o` files present in `libapps.a`

bug: v/89553